### PR TITLE
Cleanup of REST API

### DIFF
--- a/draft-birkholz-scitt-architecture.md
+++ b/draft-birkholz-scitt-architecture.md
@@ -560,7 +560,7 @@ As an example, submitting a claim with an unsupported signature algorithm would 
 
 ~~~
 {
-  "type": "urn:ietf:params:scitt:error:badSignatureAlgorithm"
+  "type": "urn:ietf:params:scitt:error:badSignatureAlgorithm",
   "detail": "The claim was signed with an algorithm the server does not support"
 }
 ~~~

--- a/draft-birkholz-scitt-architecture.md
+++ b/draft-birkholz-scitt-architecture.md
@@ -662,7 +662,7 @@ Query parameters:
 
 - (Optional) `embedReceipt=true`
 
-If the query parameter `embedReceipt=true` is provided, then the claim is returned with the corresponding registration receipt embedded in the claim's COSE unprotected header. 
+If the query parameter `embedReceipt=true` is provided, then the claim is returned with the corresponding registration receipt embedded in the claim's COSE unprotected header.
 
 #### Response
 

--- a/draft-birkholz-scitt-architecture.md
+++ b/draft-birkholz-scitt-architecture.md
@@ -589,21 +589,22 @@ Body: SCITT COSE_Sign1 message
 
 One of the following:
 
-- Status 202 - Registration is successful.
-  - Header `Location: <Base URL>/operations/<Operation ID>`
+- Status 201 - Registration is successful.
+  - Header `Location: <Base URL>/entries/<Entry ID>`
   - Header `Content-Type: application/json`
-  - Body `{ "operationId": "<Operation ID>", "status": "succeeded", "entryId": "<Entry ID"> }`
+  - Body `{ "entryId": "<Entry ID"> }`
 
 - Status 202 - Registration is pending.
   - Header `Location: <Base URL>/operations/<Operation ID>`
   - Header `Content-Type: application/json`
+  - (Optional) Header: `Retry-After: <seconds>`
   - Body `{ "operationId": "<Operation ID>", "status": "pending" }`
 
 - Status 400 - Registration was unsuccessful due to invalid input.
   - Error code `badSignatureAlgorithm`
   - Error code `TBD`
 
-If 202 is returned with status `pending`, then clients should wait until registration succeeded or failed by polling the registration status using the Operation ID returned in the response. Clients should always obtain a receipt as a proof that registration has succeeded.
+If 202 is returned, then clients should wait until registration succeeded or failed by polling the registration status using the Operation ID returned in the response. Clients should always obtain a receipt as a proof that registration has succeeded.
 
 ### Retrieve Operation Status
 
@@ -637,7 +638,7 @@ One of the following:
     - Error code: `operationNotFound`
     - This can happen if the operation ID has expired and been deleted.
 
-If an operation failed, then error details are embedded as a JSON problem details object in the `"error"` field.
+If an operation failed, then error details SHOULD be embedded as a JSON problem details object in the `"error"` field.
 
 If an operation ID is invalid (i.e., it does not correspond to any submit operation), a service may return either a 404 or a `pending` status. This is because differentiating between the two may not be possible in an eventually consistent system.
 

--- a/draft-birkholz-scitt-architecture.md
+++ b/draft-birkholz-scitt-architecture.md
@@ -588,7 +588,7 @@ One of the following:
 - Status 202 - Registration is successful.
   - Header `Location: <Base URL>/operations/<Operation ID>`
   - Header `Content-Type: application/json`
-  - Body `{ "operationId": "<Operation ID>", "status": "registered", "entryId": "<Entry ID"> }`
+  - Body `{ "operationId": "<Operation ID>", "status": "succeeded", "entryId": "<Entry ID"> }`
 
 - Status 202 - Registration is pending.
   - Header `Location: <Base URL>/operations/<Operation ID>`
@@ -620,7 +620,7 @@ One of the following:
 - Status 200 - Registration was successful
     - Header: `Location: <Base URL>/entries/<Entry ID>`
     - Header: `Content-Type: application/json`
-    - Body: `{ "operationId": "<Operation ID>", "status": "registered", "entryId": "<Entry ID>" }`
+    - Body: `{ "operationId": "<Operation ID>", "status": "succeeded", "entryId": "<Entry ID>" }`
 
 - Status 200 - Registration failed
     - Header `Content-Type: application/json`
@@ -647,7 +647,7 @@ One of the following:
 
 - Status 200.
   - Header `Content-Type: application/json`
-  - Body `{ "entryId": "<Entry ID>", "status": "registered" }`
+  - Body `{ "entryId": "<Entry ID>" }`
 - Status 404 - Entry not found.
   - Error code: `NotFound`
 

--- a/draft-birkholz-scitt-architecture.md
+++ b/draft-birkholz-scitt-architecture.md
@@ -565,7 +565,7 @@ Error responses common to all messages are the following:
 
 - Status 503 - Service not ready, retry later.
   - Error code: implementation-defined
-  - (Optional) Header: `Retry-Later: <seconds>`
+  - (Optional) Header: `Retry-After: <seconds>`
 
 ### Register Signed Claims
 
@@ -614,6 +614,7 @@ One of the following:
 
 - Status 200 - Registration is pending
     - Header: `Content-Type: application/json`
+    - (Optional) Header: `Retry-After: <seconds>`
     - Body: `{ "operationId": "<Operation ID>", "status": "pending" }`
 
 - Status 200 - Registration was successful

--- a/draft-birkholz-scitt-architecture.md
+++ b/draft-birkholz-scitt-architecture.md
@@ -558,7 +558,7 @@ Error responses SHOULD be sent with the `Content-Type: application/problem+json`
 
 As an example, submitting a claim with an unsupported signature algorithm would return a `400 Bad Request` status code and the following body:
 
-~~~
+~~~json
 {
   "type": "urn:ietf:params:scitt:error:badSignatureAlgorithm",
   "detail": "The claim was signed with an algorithm the server does not support"


### PR DESCRIPTION
It's not clear yet whether and in what form a REST API will be standardized but this PR cleans up the existing section and makes the API vendor-neutral (previously, some CCF-specific bits had leaked into it) including allowing for registration of claims to be a long-running operation which provides more flexibility for implementations.